### PR TITLE
Add checks to verify the support for incoming machine class

### DIFF
--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -10,6 +10,7 @@ metadata:
 secretRef:
   name: core-openstack
   namespace: shoot--foobar--openstack
+provider: OpenStack
 providerSpec:
   apiVersion: openstack.machine.gardener.cloud/v1alpha1
   kind: MachineProviderConfig

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -61,6 +61,12 @@ func (p *OpenstackDriver) CreateMachine(ctx context.Context, req *driver.CreateM
 	klog.V(2).Infof("machine creation request has been received for %q", req.Machine.Name)
 	defer klog.V(2).Infof("machine creation request has been processed for %q", req.Machine.Name)
 
+	// Check if incoming provider in the MachineClass is a provider we support
+	if req.MachineClass.Provider != openstackProvider {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, openstackProvider)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	providerConfig, err := p.decodeProviderSpec(req.MachineClass.ProviderSpec)
 	if err != nil {
 		klog.Errorf("decoding provider spec for machine class %q failed with: %v", req.MachineClass.Name, err)
@@ -111,6 +117,12 @@ func (p *OpenstackDriver) DeleteMachine(ctx context.Context, req *driver.DeleteM
 	klog.V(2).Infof("machine deletion request has been received for %q", req.Machine.Name)
 	defer klog.V(2).Infof("machine deletion request has been processed for %q", req.Machine.Name)
 
+	// Check if incoming provider in the MachineClass is a provider we support
+	if req.MachineClass.Provider != openstackProvider {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, openstackProvider)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	providerConfig, err := p.decodeProviderSpec(req.MachineClass.ProviderSpec)
 	if err != nil {
 		klog.V(2).Infof("decoding provider spec for machine class %q failed with: %v", req.MachineClass.Name, err)
@@ -160,6 +172,12 @@ func (p *OpenstackDriver) GetMachineStatus(ctx context.Context, req *driver.GetM
 	// Log messages to track start and end of request
 	klog.V(2).Infof("Get request has been received for %q", req.Machine.Name)
 	defer klog.V(2).Infof("Machine get request has been processed for %q", req.Machine.Name)
+
+	// Check if incoming provider in the MachineClass is a provider we support
+	if req.MachineClass.Provider != openstackProvider {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, openstackProvider)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	providerConfig, err := p.decodeProviderSpec(req.MachineClass.ProviderSpec)
 	if err != nil {
@@ -212,6 +230,12 @@ func (p *OpenstackDriver) ListMachines(ctx context.Context, req *driver.ListMach
 	// Log messages to track start and end of request
 	klog.V(2).Infof("list machines request has been received for %q", req.MachineClass.Name)
 	defer klog.V(2).Infof("list machines request has been processed for %q", req.MachineClass.Name)
+
+	// Check if incoming provider in the MachineClass is a provider we support
+	if req.MachineClass.Provider != openstackProvider {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, openstackProvider)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	providerConfig, err := p.decodeProviderSpec(req.MachineClass.ProviderSpec)
 	if err != nil {

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	openstackProvider = "openstack"
+	openstackProvider = "OpenStack"
 )
 
 func (p *OpenstackDriver) decodeProviderSpec(raw runtime.RawExtension) (*openstack.MachineProviderConfig, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Check to validate if the MachineClass in the scope is the MachineClass for the corresponding cloud provider

**Which issue(s) this PR fixes**:
Fixes [#599](https://github.com/gardener/machine-controller-manager/issues/599)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```