### PR TITLE
Fix used region for Neutron client

### DIFF
--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -168,5 +168,5 @@ func (f *Factory) Network(opts ...Option) (Network, error) {
 		eo = opt(eo)
 	}
 
-	return newNeutronV2(f.providerClient, gophercloud.EndpointOpts{})
+	return newNeutronV2(f.providerClient, eo)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue which discarded the region configuration for the Neutron client.

**Special notes for your reviewer**:
/invite @kon-angelo 
/cc @vasu1124 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed which prevented ports from being patched properly after machine creations.
```