### PR TITLE
add support for authentication with application credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #############      builder                                  #############
-FROM eu.gcr.io/gardener-project/3rd/golang:1.16.2 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.16.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager-provider-openstack
 COPY . .
@@ -11,7 +11,7 @@ RUN make install
 RUN ls -la /go/bin
 
 #############      base                                     #############
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.13.4 AS base
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.13.5 AS base
 
 RUN apk add --update bash curl tzdata
 WORKDIR /

--- a/pkg/apis/cloudprovider/cloudprovider.go
+++ b/pkg/apis/cloudprovider/cloudprovider.go
@@ -27,6 +27,11 @@ const (
 	OpenStackUsername string = "username"
 	// OpenStackPassword is a constant for a key name that is part of the OpenStack cloud Credentials.
 	OpenStackPassword string = "password"
+	// OpenStackApplicationCredentialID is a constant for a key name that is part of the OpenStack cloud Credentials.
+	OpenStackApplicationCredentialID = "applicationCredentialID"
+	// OpenStackApplicationCredentialSecret is a constant for a key name that is part of the OpenStack cloud Credentials.
+	OpenStackApplicationCredentialSecret = "applicationCredentialSecret"
+
 	// OpenStackClientCert is a constant for a key name that is part of the OpenStack cloud Credentials.
 	OpenStackClientCert string = "clientCert"
 	// OpenStackClientKey is a constant for a key name that is part of the OpenStack cloud Credentials.

--- a/pkg/apis/validation/validation.go
+++ b/pkg/apis/validation/validation.go
@@ -124,11 +124,20 @@ func validateSecret(secret *corev1.Secret) field.ErrorList {
 	if b, ok := data[OpenStackAuthURL]; !ok || isEmptyStringByteSlice(b) {
 		allErrs = append(allErrs, field.Required(root.Key(OpenStackAuthURL), fmt.Sprintf("%s is required", OpenStackAuthURL)))
 	}
-	if b, ok := data[OpenStackUsername]; !ok || isEmptyStringByteSlice(b) {
-		allErrs = append(allErrs, field.Required(root.Key(OpenStackUsername), fmt.Sprintf("%s is required", OpenStackUsername)))
-	}
-	if b, ok := data[OpenStackPassword]; !ok || isEmptyStringByteSlice(b) {
-		allErrs = append(allErrs, field.Required(root.Key(OpenStackPassword), fmt.Sprintf("%s is required", OpenStackPassword)))
+	if _, ok := data[OpenStackApplicationCredentialID]; !ok {
+		if b, ok := data[OpenStackUsername]; !ok || isEmptyStringByteSlice(b) {
+			allErrs = append(allErrs, field.Required(root.Key(OpenStackUsername), fmt.Sprintf("%s is required", OpenStackUsername)))
+		}
+		if b, ok := data[OpenStackPassword]; !ok || isEmptyStringByteSlice(b) {
+			allErrs = append(allErrs, field.Required(root.Key(OpenStackPassword), fmt.Sprintf("%s is required", OpenStackPassword)))
+		}
+	} else {
+		if b, ok := data[OpenStackApplicationCredentialID]; !ok || isEmptyStringByteSlice(b) {
+			allErrs = append(allErrs, field.Required(root.Key(OpenStackApplicationCredentialID), fmt.Sprintf("%s is required", OpenStackApplicationCredentialID)))
+		}
+		if b, ok := data[OpenStackApplicationCredentialSecret]; !ok || isEmptyStringByteSlice(b) {
+			allErrs = append(allErrs, field.Required(root.Key(OpenStackApplicationCredentialSecret), fmt.Sprintf("%s is required", OpenStackApplicationCredentialSecret)))
+		}
 	}
 
 	domainName, ok := data[OpenStackDomainName]

--- a/pkg/client/credentials.go
+++ b/pkg/client/credentials.go
@@ -22,14 +22,17 @@ type credentials struct {
 	TenantName string
 
 	Username string
+	Password string
+
+	ApplicationCredentialID     string
+	ApplicationCredentialSecret string
 
 	CACert     []byte
 	ClientKey  []byte
 	ClientCert []byte
 	Insecure   bool
 
-	Password string
-	AuthURL  string
+	AuthURL string
 }
 
 func extractCredentialsFromSecret(secret *corev1.Secret) *credentials {
@@ -38,6 +41,9 @@ func extractCredentialsFromSecret(secret *corev1.Secret) *credentials {
 	authURL := data[cloudprovider.OpenStackAuthURL]
 	username := data[cloudprovider.OpenStackUsername]
 	password := data[cloudprovider.OpenStackPassword]
+
+	applicationCredentialID := data[cloudprovider.OpenStackApplicationCredentialID]
+	applicationCredentialSecret := data[cloudprovider.OpenStackApplicationCredentialSecret]
 
 	// optional OS_USER_DOMAIN_NAME
 	userDomainName := data[cloudprovider.OpenStackUserDomainName]
@@ -65,18 +71,20 @@ func extractCredentialsFromSecret(secret *corev1.Secret) *credentials {
 	insecure := strings.TrimSpace(string(data[cloudprovider.OpenStackInsecure])) == "true"
 
 	return &credentials{
-		DomainName:     strings.TrimSpace(string(domainName)),
-		DomainID:       strings.TrimSpace(string(domainID)),
-		UserDomainName: strings.TrimSpace(string(userDomainName)),
-		UserDomainID:   strings.TrimSpace(string(userDomainID)),
-		TenantName:     strings.TrimSpace(string(tenantName)),
-		TenantID:       strings.TrimSpace(string(tenantID)),
-		Username:       strings.TrimSpace(string(username)),
-		Password:       strings.TrimSpace(string(password)),
-		AuthURL:        strings.TrimSpace(string(authURL)),
-		ClientCert:     clientCert,
-		ClientKey:      clientKey,
-		CACert:         caCert,
-		Insecure:       insecure,
+		DomainName:                  strings.TrimSpace(string(domainName)),
+		DomainID:                    strings.TrimSpace(string(domainID)),
+		UserDomainName:              strings.TrimSpace(string(userDomainName)),
+		UserDomainID:                strings.TrimSpace(string(userDomainID)),
+		TenantName:                  strings.TrimSpace(string(tenantName)),
+		TenantID:                    strings.TrimSpace(string(tenantID)),
+		Username:                    strings.TrimSpace(string(username)),
+		Password:                    strings.TrimSpace(string(password)),
+		ApplicationCredentialID:     strings.TrimSpace(string(applicationCredentialID)),
+		ApplicationCredentialSecret: strings.TrimSpace(string(applicationCredentialSecret)),
+		AuthURL:                     strings.TrimSpace(string(authURL)),
+		ClientCert:                  clientCert,
+		ClientKey:                   clientKey,
+		CACert:                      caCert,
+		Insecure:                    insecure,
 	}
 }

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -69,17 +69,23 @@ func newAuthenticatedProviderClientFromCredentials(credentials *credentials) (*g
 
 	clientOpts := new(clientconfig.ClientOpts)
 	authInfo := &clientconfig.AuthInfo{
-		AuthURL:        credentials.AuthURL,
-		Username:       credentials.Username,
-		Password:       credentials.Password,
-		DomainName:     credentials.DomainName,
-		DomainID:       credentials.DomainID,
-		ProjectName:    credentials.TenantName,
-		ProjectID:      credentials.TenantID,
-		UserDomainName: credentials.UserDomainName,
-		UserDomainID:   credentials.UserDomainID,
+		AuthURL:                     credentials.AuthURL,
+		Username:                    credentials.Username,
+		Password:                    credentials.Password,
+		DomainName:                  credentials.DomainName,
+		DomainID:                    credentials.DomainID,
+		ProjectName:                 credentials.TenantName,
+		ProjectID:                   credentials.TenantID,
+		UserDomainName:              credentials.UserDomainName,
+		UserDomainID:                credentials.UserDomainID,
+		ApplicationCredentialID:     credentials.ApplicationCredentialID,
+		ApplicationCredentialSecret: credentials.ApplicationCredentialSecret,
 	}
 	clientOpts.AuthInfo = authInfo
+
+	if clientOpts.AuthInfo.ApplicationCredentialID != "" {
+		clientOpts.AuthType = clientconfig.AuthV3ApplicationCredential
+	}
 
 	ao, err := clientconfig.AuthOptions(clientOpts)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The secret backing the machine class object can contain the keys `applicationCredentialID` and `applicationCredentialSecret` as alternative to authentication with username/password.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
add support for authentication with application credentials
```