### PR TITLE
support for applicationCredentialName

### DIFF
--- a/pkg/apis/cloudprovider/cloudprovider.go
+++ b/pkg/apis/cloudprovider/cloudprovider.go
@@ -29,6 +29,8 @@ const (
 	OpenStackPassword string = "password"
 	// OpenStackApplicationCredentialID is a constant for a key name that is part of the OpenStack cloud Credentials.
 	OpenStackApplicationCredentialID = "applicationCredentialID"
+	// OpenStackApplicationCredentialName is a constant for a key name that is part of the OpenStack cloud Credentials.
+	OpenStackApplicationCredentialName = "applicationCredentialName"
 	// OpenStackApplicationCredentialSecret is a constant for a key name that is part of the OpenStack cloud Credentials.
 	OpenStackApplicationCredentialSecret = "applicationCredentialSecret"
 

--- a/pkg/apis/validation/validation_test.go
+++ b/pkg/apis/validation/validation_test.go
@@ -206,27 +206,62 @@ var _ = Describe("Validation", func() {
 					"Type":  BeEquivalentTo("FieldValueRequired"),
 					"Field": Equal("data[tenantName]"),
 				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  BeEquivalentTo("FieldValueRequired"),
+					"Field": Equal("data[applicationCredentialID]"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  BeEquivalentTo("FieldValueRequired"),
+					"Field": Equal("data[applicationCredentialName]"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  BeEquivalentTo("FieldValueRequired"),
+					"Field": Equal("data[applicationCredentialSecret]"),
+				})),
 			))
 		})
 
-		It("should fail if application credential secret field is missing", func() {
-			delete(secret.Data, OpenStackUsername)
+		It("should fail if application credential id or name field are missing", func() {
 			delete(secret.Data, OpenStackPassword)
-			secret.Data[OpenStackApplicationCredentialID] = []byte("app-id")
+			secret.Data[OpenStackApplicationCredentialSecret] = []byte("app-secret")
 
 			err := validateSecret(secret)
 			Expect(err).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  BeEquivalentTo("FieldValueRequired"),
-					"Field": Equal("data[" + OpenStackApplicationCredentialSecret + "]"),
+					"Field": Equal("data[" + OpenStackApplicationCredentialID + "]"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  BeEquivalentTo("FieldValueRequired"),
+					"Field": Equal("data[" + OpenStackApplicationCredentialName + "]"),
 				})),
 			))
 		})
 
-		It("should succeed if application credentials are used", func() {
+		It("should succeed if application credentials are used (id + secret)", func() {
 			delete(secret.Data, OpenStackUsername)
 			delete(secret.Data, OpenStackPassword)
 			secret.Data[OpenStackApplicationCredentialID] = []byte("app-id")
+			secret.Data[OpenStackApplicationCredentialSecret] = []byte("app-secret")
+
+			err := validateSecret(secret).ToAggregate()
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed if application credentials are used (id + name + secret)", func() {
+			delete(secret.Data, OpenStackUsername)
+			delete(secret.Data, OpenStackPassword)
+			secret.Data[OpenStackApplicationCredentialID] = []byte("app-id")
+			secret.Data[OpenStackApplicationCredentialName] = []byte("app-name")
+			secret.Data[OpenStackApplicationCredentialSecret] = []byte("app-secret")
+
+			err := validateSecret(secret).ToAggregate()
+			Expect(err).To(BeNil())
+		})
+
+		It("should succeed if application credentials are used (username + name + secret)", func() {
+			delete(secret.Data, OpenStackPassword)
+			secret.Data[OpenStackApplicationCredentialName] = []byte("app-name")
 			secret.Data[OpenStackApplicationCredentialSecret] = []byte("app-secret")
 
 			err := validateSecret(secret).ToAggregate()

--- a/pkg/client/credentials.go
+++ b/pkg/client/credentials.go
@@ -25,6 +25,7 @@ type credentials struct {
 	Password string
 
 	ApplicationCredentialID     string
+	ApplicationCredentialName   string
 	ApplicationCredentialSecret string
 
 	CACert     []byte
@@ -43,6 +44,7 @@ func extractCredentialsFromSecret(secret *corev1.Secret) *credentials {
 	password := data[cloudprovider.OpenStackPassword]
 
 	applicationCredentialID := data[cloudprovider.OpenStackApplicationCredentialID]
+	applicationCredentialName := data[cloudprovider.OpenStackApplicationCredentialName]
 	applicationCredentialSecret := data[cloudprovider.OpenStackApplicationCredentialSecret]
 
 	// optional OS_USER_DOMAIN_NAME
@@ -80,6 +82,7 @@ func extractCredentialsFromSecret(secret *corev1.Secret) *credentials {
 		Username:                    strings.TrimSpace(string(username)),
 		Password:                    strings.TrimSpace(string(password)),
 		ApplicationCredentialID:     strings.TrimSpace(string(applicationCredentialID)),
+		ApplicationCredentialName:   strings.TrimSpace(string(applicationCredentialName)),
 		ApplicationCredentialSecret: strings.TrimSpace(string(applicationCredentialSecret)),
 		AuthURL:                     strings.TrimSpace(string(authURL)),
 		ClientCert:                  clientCert,

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -79,11 +79,12 @@ func newAuthenticatedProviderClientFromCredentials(credentials *credentials) (*g
 		UserDomainName:              credentials.UserDomainName,
 		UserDomainID:                credentials.UserDomainID,
 		ApplicationCredentialID:     credentials.ApplicationCredentialID,
+		ApplicationCredentialName:   credentials.ApplicationCredentialName,
 		ApplicationCredentialSecret: credentials.ApplicationCredentialSecret,
 	}
 	clientOpts.AuthInfo = authInfo
 
-	if clientOpts.AuthInfo.ApplicationCredentialID != "" {
+	if clientOpts.AuthInfo.ApplicationCredentialSecret != "" {
 		clientOpts.AuthType = clientconfig.AuthV3ApplicationCredential
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Also support authentication with application credentials using (`username`,`applicationCredentialName`,  `applicationCredentialSecret`) instead of (`applicationCredentialID`, `applicationCredentialSecret`)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user

```