### PR TITLE
Fix machine creation from imageName

### DIFF
--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -250,7 +250,7 @@ func (ex *Executor) deployServer(machineName string, userData []byte, nws []serv
 
 	// If a custom block_device (root disk size is provided) we need to boot from volume
 	if rootDiskSize > 0 {
-		return ex.bootFromVolume(machineName, imageID, createOpts)
+		return ex.bootFromVolume(machineName, imageRef, createOpts)
 	}
 
 	return ex.Compute.CreateServer(createOpts)


### PR DESCRIPTION
/kind bug
/kind regression

Fixes #48

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```bugfix user
A regression in Machine creation from imageName is now fixed.
```