### PR TITLE
[rel-v0.8] Automated cherry pick of #47: Use proper version of klog

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/gardener/machine-controller-manager-provider-openstack/pkg/apis/openstack/install"
 	"github.com/gardener/machine-controller-manager-provider-openstack/pkg/driver"

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	k8s.io/apimachinery v0.22.2
 	k8s.io/code-generator v0.22.2
 	k8s.io/component-base v0.22.2
-	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.9.0
 	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
 )
 
@@ -102,7 +102,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible // indirect
 	k8s.io/cluster-bootstrap v0.22.2 // indirect
 	k8s.io/gengo v0.0.0-20201113003025-83324d819ded // indirect
-	k8s.io/klog/v2 v2.9.0 // indirect
+	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20211005045149-78ce10e2ebad // indirect
 	sigs.k8s.io/controller-tools v0.7.0 // indirect

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gophercloud/utils/client"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // Factory can create clients for Nova and Neutron OpenStack services.
@@ -115,7 +115,7 @@ func newAuthenticatedProviderClientFromCredentials(credentials *credentials) (*g
 		Transport: transport,
 	}
 
-	if klog.V(6) {
+	if klog.V(6).Enabled() {
 		provider.HTTPClient.Transport = &client.RoundTripper{
 			Rt:     provider.HTTPClient.Transport,
 			Logger: &logger{},
@@ -134,7 +134,7 @@ type logger struct{}
 
 func (l logger) Printf(format string, args ...interface{}) {
 	// extra check in case, when verbosity has been changed dynamically
-	if klog.V(6) {
+	if klog.V(6).Enabled() {
 		var skip int
 		var found bool
 		gc := "/github.com/gophercloud/gophercloud"

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/gardener/machine-controller-manager-provider-openstack/pkg/apis/cloudprovider"
 	"github.com/gardener/machine-controller-manager-provider-openstack/pkg/apis/validation"

--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 
 	api "github.com/gardener/machine-controller-manager-provider-openstack/pkg/apis/openstack"


### PR DESCRIPTION
/area/dev-productivity
/area/ops-productivity
/kind/bug

Cherry pick of #47 on rel-v0.8.

#47: Use proper version of klog

**Release Notes:**
```bugfix operator
An issue causing klog's `--v` flag to be not respected is now fixed.
```