### PR TITLE
[rel-v0.8] Automated cherry pick of #49: Fix machine creation from imageName

### DIFF
--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -250,7 +250,7 @@ func (ex *Executor) deployServer(machineName string, userData []byte, nws []serv
 
 	// If a custom block_device (root disk size is provided) we need to boot from volume
 	if rootDiskSize > 0 {
-		return ex.bootFromVolume(machineName, imageID, createOpts)
+		return ex.bootFromVolume(machineName, imageRef, createOpts)
 	}
 
 	return ex.Compute.CreateServer(createOpts)


### PR DESCRIPTION
/kind/bug
/kind/regression

Cherry pick of #49 on rel-v0.8.

#49: Fix machine creation from imageName

**Release Notes:**
```bugfix user
A regression in Machine creation from imageName is now fixed.
```