### PR TITLE
Fixed missing volume status downloading

### DIFF
--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -318,7 +318,9 @@ func (ex *Executor) ensureVolume(name, imageID string) (string, error) {
 		volumeID = volume.ID
 	}
 
-	if err := ex.waitForVolumeStatus(volumeID, []string{client.VolumeStatusCreating}, []string{client.VolumeStatusAvailable}, 600); err != nil {
+	pendingStatuses = []string{client.VolumeStatusCreating, client.VolumeStatusDownloading}
+	targetStatuses = []string{client.VolumeStatusAvailable}
+	if err := ex.waitForVolumeStatus(volumeID, pendingStatuses, targetStatuses, 600); err != nil {
 		return "", err
 	}
 

--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -318,8 +318,8 @@ func (ex *Executor) ensureVolume(name, imageID string) (string, error) {
 		volumeID = volume.ID
 	}
 
-	pendingStatuses = []string{client.VolumeStatusCreating, client.VolumeStatusDownloading}
-	targetStatuses = []string{client.VolumeStatusAvailable}
+	pendingStatuses := []string{client.VolumeStatusCreating, client.VolumeStatusDownloading}
+	targetStatuses := []string{client.VolumeStatusAvailable}
 	if err := ex.waitForVolumeStatus(volumeID, pendingStatuses, targetStatuses, 600); err != nil {
 		return "", err
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:
Adds the missing pending state downloading.

**Which issue(s) this PR fixes**:
Fixes #60 

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
Fixed missing volume status VolumeStatusDownloading when creating volume
```