### PR TITLE
fix issue with g/g scripts not having correct permissions

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -36,5 +36,4 @@ new_version="github.com/gardener/machine-controller-manager ${DEPENDENCY_VERSION
 sed -i -- 's#'"${old_version}"'#'"${new_version}"'#g' go.mod
 apk add --no-cache go make
 
-go mod tidy -v
-go mod vendor -v
+make revendor


### PR DESCRIPTION
**What this PR does / why we need it**:

Run `make revendor` because the revendor command also makes vendored gardener scripts executable.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement user
Fix an issue where automatic revendoring did not assign correct permissions to CI scripts.
```