### PR TITLE
fix multiple ports during delete

### DIFF
--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -537,11 +537,13 @@ func (ex *Executor) deletePort(_ context.Context, machineName string) error {
 		return fmt.Errorf("error deleting port [Name=%q]: %s", machineName, err)
 	}
 	if len(portList) == 0 {
-		klog.V(3).Infof("port [Name=%q] was not found", machineName)
+		klog.V(2).Infof("port [Name=%q] was not found", machineName)
 		return nil
 	}
 
+	klog.V(2).Infof("deleting ports for machine [Name=%q]", machineName)
 	for _, p := range portList {
+		klog.V(2).Infof("deleting port [ID=%q]", p.ID)
 		err = ex.Network.DeletePort(p.ID)
 		if err != nil {
 			klog.Errorf("failed to delete port [ID=%q]: %s", p.ID, err)

--- a/pkg/driver/executor/executor_test.go
+++ b/pkg/driver/executor/executor_test.go
@@ -396,7 +396,7 @@ var _ = Describe("Executor", func() {
 				compute.EXPECT().GetServer("id1").Return(&servers.Server{Status: client.ServerStatusDeleted}, nil),
 			)
 			gomock.InOrder(
-				network.EXPECT().PortIDFromName(machineName).Return(portID, nil),
+				network.EXPECT().ListPorts(ports.ListOpts{Name: machineName}).Return([]ports.Port{{ID: portID}}, nil),
 				network.EXPECT().DeletePort(portID).Return(nil),
 			)
 
@@ -409,10 +409,11 @@ var _ = Describe("Executor", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should try to delete the port if we use specific subnetID", func() {
+		It("should delete all ports if multiple are found", func() {
 			var (
 				subnetID    = "subID1"
-				portID      = "portID"
+				portID1     = "portID1"
+				portID2     = "portID2"
 				machineName = "foo"
 			)
 
@@ -423,8 +424,9 @@ var _ = Describe("Executor", func() {
 				compute.EXPECT().GetServer("id1").Return(&servers.Server{Status: client.ServerStatusDeleted}, nil),
 			)
 			gomock.InOrder(
-				network.EXPECT().PortIDFromName(machineName).Return(portID, nil),
-				network.EXPECT().DeletePort(portID).Return(nil),
+				network.EXPECT().ListPorts(ports.ListOpts{Name: machineName}).Return([]ports.Port{{ID: portID1}, {ID: portID2}}, nil),
+				network.EXPECT().DeletePort(portID1).Return(nil),
+				network.EXPECT().DeletePort(portID2).Return(nil),
 			)
 
 			ex := Executor{


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/machine-controller-manager-provider-openstack/issues/54

**Special notes for your reviewer**:
Delete all ports matching machine name.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug user
Delete all ports matching machine name.
```