### PR TITLE
Add cve categorization for mcm-provider-openstack

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -13,6 +13,15 @@ machine-controller-manager-provider-openstack:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-openstack'
             target: machine-controller
+            resource_labels:
+            - name: 'gardener.cloud/cve-categorisation'
+              value:
+                network_exposure: 'protected'
+                authentication_enforced: false
+                user_interaction: 'gardener-operator'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'high'
+                availability_requirement: 'low'
   jobs:
     create-upgrade-prs:
       traits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add cve categorization for mcm-provider-openstack.

The categorization was initially defined here and it transferred as defined to the mcm-provider-openstack repository: 
https://github.com/gardener/gardener-extension-provider-openstack/pull/553 

We move the cve categorization to the mcm-provider-openstack repository as the categorization can't be taken into consideration when it is defined in the respective provider extension project. Once this behaviour has changed we can remove the categorisation here again.

**Release note**:
```other operator
CVE categorization for mcm-provider-openstack has been added.
```
