### PR TITLE
Moved Declaration of dynamic content from Makefile to .env file for OPENSTACK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /tmp/*
 /dev
 /hack/tools/bin
-
+.env
 .vscode
 .idea
 *.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,7 @@ IMAGE_PREFIX        := $(REGISTRY)/extensions
 NAME                := machine-controller-manager-provider-openstack
 IMAGE_NAME          := $(IMAGE_PREFIX)/$(NAME)
 VERSION             := $(shell cat VERSION)
-CONTROL_NAMESPACE   := default
-CONTROL_KUBECONFIG  ?= dev/control-kubeconfig.yaml
-TARGET_KUBECONFIG   ?= dev/target-kubeconfig.yaml
 
-# Below ones are used in tests
-MACHINECLASS_V1 	:= dev/machineclassv1.yaml
-MACHINECLASS_V2 	:= 
-MCM_IMAGE			:= 
-MC_IMAGE			:= 
-# MCM_IMAGE			:= eu.gcr.io/gardener-project/gardener/machine-controller-manager:v0.42.0
-# MC_IMAGE			:= $(IMAGE_NAME):v0.6.0
 LEADER_ELECT 	    := "true"
 # If Integration Test Suite is to be run locally against clusters then export the below variable
 # with MCM deployment name in the cluster
@@ -33,6 +23,7 @@ MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 
 TOOLS_DIR := hack/tools
 include vendor/github.com/gardener/gardener/hack/tools.mk
+include .env
 
 #################################################
 # Rules for starting machine-controller locally

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+include vendor/github.com/gardener/gardener/hack/tools.mk
+-include .env
+
 BINARY_PATH         := bin/
 REPO_ROOT           := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 HACK_DIR            := $(REPO_ROOT)/hack
@@ -22,8 +25,6 @@ MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 #########################################
 
 TOOLS_DIR := hack/tools
-include vendor/github.com/gardener/gardener/hack/tools.mk
--include .env
 
 #################################################
 # Rules for starting machine-controller locally

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 
 TOOLS_DIR := hack/tools
 include vendor/github.com/gardener/gardener/hack/tools.mk
-include .env
+-include .env
 
 #################################################
 # Rules for starting machine-controller locally


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates Makefile content to import dynamic content from the .env file.

**Which issue(s) this PR fixes**:
Fixes -> https://github.com/gardener/machine-controller-manager/issues/846 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement user
NONE
```