### PR TITLE
fix: configure update-dependencies-job to look for releases

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -26,6 +26,8 @@ machine-controller-manager-provider-openstack:
       traits:
         cronjob:
           interval: '24h'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         update_component_deps:
           set_dependency_version_script_container_image:
             image_reference: 'golang:1.20.5'


### PR DESCRIPTION
**What this PR does / why we need it**

Fix an oversight from https://github.com/gardener/machine-controller-manager-provider-openstack/pull/105: update-component-deps needs to "see" release-versions (from `releases` ocm repository).

This change will have no visible impact for users of this component (therefore I did not add a release-note).