### PR TITLE
Set DeleteOnTermination for in BlockDeviceMappings to false in case of volumes with RootDiskType

### DIFF
--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -269,7 +269,7 @@ func (ex *Executor) bootFromVolume(machineName, imageID string, createOpts serve
 			UUID:                volumeID,
 			VolumeSize:          ex.Config.Spec.RootDiskSize,
 			BootIndex:           0,
-			DeleteOnTermination: true,
+			DeleteOnTermination: false,
 			SourceType:          "volume",
 			DestinationType:     "volume",
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

In case of a `RootDiskType` is specified the volume will be created before creating the server. Also while deletion the server gets deleted first and than also the volume is getting deleted.
In the `BlockDeviceMapping` currently we set `DeleteOnTermination: true` this is wrong because the volume gets deleted by the mcm.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Set DeleteOnTermination for in BlockDeviceMappings to false in case of volumes with RootDiskType.
```