### PR TITLE
Increase openstack poll interval

### DIFF
--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -163,7 +163,7 @@ func (ex *Executor) resolveServerNetworks(ctx context.Context, machineName strin
 func (ex *Executor) waitForServerStatus(ctx context.Context, serverID string, pending []string, target []string, secs int) error {
 	return wait.PollUntilContextTimeout(
 		ctx,
-		time.Second,
+		10*time.Second,
 		time.Duration(secs)*time.Second,
 		false,
 		func(_ context.Context) (done bool, err error) {
@@ -335,7 +335,7 @@ func (ex *Executor) ensureVolume(ctx context.Context, name, imageID string) (str
 func (ex *Executor) waitForVolumeStatus(ctx context.Context, volumeID string, pending, target []string, secs int) error {
 	return wait.PollUntilContextTimeout(
 		ctx,
-		time.Second,
+		10*time.Second,
 		time.Duration(secs)*time.Second,
 		false,
 		func(_ context.Context) (done bool, err error) {

--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -165,7 +165,7 @@ func (ex *Executor) waitForServerStatus(ctx context.Context, serverID string, pe
 		ctx,
 		10*time.Second,
 		time.Duration(secs)*time.Second,
-		false,
+		true,
 		func(_ context.Context) (done bool, err error) {
 			current, err := ex.Compute.GetServer(serverID)
 			if err != nil {
@@ -337,7 +337,7 @@ func (ex *Executor) waitForVolumeStatus(ctx context.Context, volumeID string, pe
 		ctx,
 		10*time.Second,
 		time.Duration(secs)*time.Second,
-		false,
+		true,
 		func(_ context.Context) (done bool, err error) {
 			current, err := ex.Storage.GetVolume(volumeID)
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR increase the openstack poll interval from 1 second to 10 seconds. In my opinion there is no need to poll every second. All this tasks need a few second and to reduce the number of API calls against openstack is suggest to set the interval to 10 seconds.

Additionally I switched from the depricated `wait.Poll` to `wait.PollUntilContextTimeout`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
Increase openstack poll interval to reduce the number of openstack API calls.
```