### PR TITLE
Enhanced the local_integration_test script

### DIFF
--- a/.ci/local_integration_test
+++ b/.ci/local_integration_test
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 set -e
@@ -7,21 +7,288 @@ set -e
 # For the test step concourse will set the following environment variables:
 # SOURCE_PATH - path to component repository root directory.
 
+mcm_repo_link="dev"
+declare PROVIDER="openstack"
+declare PROJECT
+declare TARGET_CLUSTER
+declare CONTROL_CLUSTER
+declare GARDEN_CORE_NAMESPACE
+declare CONTROL_KUBECONFIG
+declare MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME
+declare CREDENTIALS_SECRET_NAME
+declare NAMESPACE
+DEFAULT_MCM_REPO_PATH=$(realpath "$(pwd)/../machine-controller-manager")
+DEFAULT_CREDENTIALS_SECRET_NAME="shoot-operator-ccloud-cp-eu-de1-team"
 
-mcm_repo_link="dev/mcm"
-if [[ ! -d "$mcm_repo_link" ]]; then
-  echo "Error: MCM Repo expected at: $mcm_repo_link
-    For running local Integration Tests, kindly checkout MCM Repo locally and execute 'ln -sf <absolutePathToMcmRepo> $mcm_repo_link'"
+function fetch_userdata(){
+    USERDATA_SECRET_NAME=$(kubectl get secrets -o custom-columns=Name:.metadata.name --no-headers | grep shoot--$PROJECT | head -n 1)
+    kubectl get secret $USERDATA_SECRET_NAME -oyaml > userData.yaml
+    userData=$(yq eval '.data.userData' userData.yaml)
+    echo $userData
+}
+
+
+function fetch_credentials(){
+   kubectl get secret $CREDENTIALS_SECRET_NAME -n $GARDEN_CORE_NAMESPACE -o yaml > credentials.yaml
+   applicationCredentialID=$(yq eval '.data.applicationCredentialID' credentials.yaml)
+   applicationCredentialName=$(yq eval '.data.applicationCredentialName' credentials.yaml)
+   applicationCredentialSecret=$(yq eval '.data.applicationCredentialSecret' credentials.yaml)
+   authURL=$(yq eval '.data.authURL' credentials.yaml)
+   domainName=$(yq eval '.data.domainName' credentials.yaml)
+   tenantName=$(yq eval '.data.tenantName' credentials.yaml)
+
+   echo "$applicationCredentialID" "$applicationCredentialName" "$applicationCredentialSecret" "$authURL" "$domainName" "$tenantName"
+}
+
+function create_test_mc_secret() {
+  gardenctl target --garden sap-landscape-dev
+  eval $(gardenctl kubectl-env bash)
+  read applicationCredentialID applicationCredentialName applicationCredentialSecret authURL domainName tenantName < <(fetch_credentials)
+  gardenctl target --garden sap-landscape-dev --project $PROJECT --shoot $TARGET_CLUSTER --control-plane
+  eval $(gardenctl kubectl-env bash)
+  userData=$(fetch_userdata)
+  rm -f credentials.yaml
+  rm -f userData.yaml
+secret_yaml=$(cat <<EOF
+apiVersion: v1
+data:
+  applicationCredentialID: $applicationCredentialID
+  applicationCredentialName: $applicationCredentialName
+  applicationCredentialSecret: $applicationCredentialSecret
+  authURL: $authURL
+  domainName: $domainName
+  tenantName: $tenantName
+  userData: $userData
+kind: Secret
+metadata:
+  name: test-mc-secret
+  namespace: "$NAMESPACE"
+type: Opaque
+EOF
+)
+    gardenctl target --garden sap-landscape-dev --project $PROJECT --shoot $CONTROL_CLUSTER
+    eval $(gardenctl kubectl-env bash)
+    echo "$secret_yaml" | kubectl  apply -f -
+}
+
+
+printf "\e[33mDo you want to clone the latest MCM Repo? (true/false)\e[0m\n"
+read clone_mcm_repo
+
+#check if clone_mcm_repo is not empty
+if [ -z "$clone_mcm_repo" ]
+then
+      printf "\e[31mentered value cannot be empty\e[0m\n"
+      exit 1
+fi
+
+#check if clone_mcm_repo is a boolean
+if [ "$clone_mcm_repo" != true ] && [ "$clone_mcm_repo" != false ]
+then
+      printf "\e[31mentered value must be a boolean\e[0m\n"
+      exit 1
+fi
+
+if [ "$clone_mcm_repo" = true ]
+then
+    if [ ! -d "$mcm_repo_link" ]
+    then
+        mkdir -p $mcm_repo_link
+    fi
+    cd $mcm_repo_link
+    MCM_VERSION=$(go list -mod=mod -f '{{ .Version }}' -m "github.com/gardener/machine-controller-manager")
+    printf "\e[33mCloning MCM Repo with version: $MCM_VERSION\e[0m\n"
+    git clone --branch "$MCM_VERSION" --depth 1 https://github.com/gardener/machine-controller-manager
+    mv machine-controller-manager mcm
+    cd -
+fi
+
+
+if [[ ! -d "$mcm_repo_link/mcm" ]]; then
+  echo "Error: MCM Repo expected at: $mcm_repo_link/mcm
+    For running local Integration Tests, kindly checkout MCM Repo locally and execute 'ln -sf <absolutePathToMcmRepo> $mcm_repo_link/mcm'"
   exit 1
 fi
 
-cd test/integration/controller
 if ! hash ginkgo; then
     # Install Ginkgo (test framework) to be able to execute the tests.
     echo "Fetching Ginkgo frawework"
-    GO111MODULE=off go install github.com/onsi/ginkgo/v2/ginkgo
+    GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
     echo "Successfully fetched Ginkgo frawework"
 fi
 
-echo "Starting integration tests..."
-ginkgo -v --show-node-events --poll-progress-after=480s --poll-progress-interval=90s
+printf  "\e[33mIs the control cluster a seed? (true/false)\e[0m\n"
+read IS_CONTROL_CLUSTER_SEED
+
+if [ -z "$IS_CONTROL_CLUSTER_SEED" ]
+then
+      printf "\e[31mentered value cannot be empty\e[0m\n"
+      exit 1
+fi
+
+if [ "$IS_CONTROL_CLUSTER_SEED" != true ] && [ "$IS_CONTROL_CLUSTER_SEED" != false ]
+then
+      printf "\e[31mentered value must be a boolean\e[0m\n"
+      exit 1
+fi
+export IS_CONTROL_CLUSTER_SEED=$IS_CONTROL_CLUSTER_SEED
+
+printf "\e[33mEnter the absolute path to the local machine-controller-manager repository.\e[0m\n"
+printf "\e[33mNote: Default path is $DEFAULT_MCM_REPO_PATH. Press Enter to proceed with it.\e[0m\n"
+read MCM_REPO_PATH
+if [ -z "$MCM_REPO_PATH" ]
+then
+      MCM_REPO_PATH="$DEFAULT_MCM_REPO_PATH"
+fi
+if [ ! -d "$MCM_REPO_PATH" ]
+then
+      printf "\e[31m$MCM_REPO_PATH is not a valid directory\e[0m\n"
+      exit 1
+fi
+
+printf "\e[33mEnter the project name. (Enter NA if it is not a gardener setup and you intend to deploy the secret manually) \e[0m\n"
+read PROJECT
+if [ -z "$PROJECT" ]
+then
+    printf "\e[31mproject cannot be empty\e[0m\n"
+    exit 1
+fi
+printf "\e[33mEnter the control cluster name\e[0m\n"
+read CONTROL_CLUSTER
+if [ -z "$CONTROL_CLUSTER" ]
+then
+    printf "\e[31mseed name cannot be empty\e[0m\n"
+    exit 1
+fi
+printf "\e[33mEnter the target cluster name\e[0m\n"
+read TARGET_CLUSTER
+if [ -z "$TARGET_CLUSTER" ]
+then
+    printf "\e[31mtarget cluster cannot be empty\e[0m\n"
+    exit 1
+fi
+
+printf "\e[33mEnter the machine-controller-manager deployment name.\e[0m\n"
+printf "\e[33mNote: Default deployment name is machine-controller-manager. Press Enter to proceed with it.\e[0m\n"
+read MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME
+if [ -z "$MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME" ]
+then
+    MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME="machine-controller-manager"
+fi
+
+if [ "$IS_CONTROL_CLUSTER_SEED" = true ]
+then
+    cd $MCM_REPO_PATH
+    ./hack/gardener_local_setup.sh --seed "$CONTROL_CLUSTER" --shoot "$TARGET_CLUSTER" --project "$PROJECT" --provider "$PROVIDER"
+    cd -
+    printf "\n%s" "TARGET_CLUSTER_NAME=shoot--${PROJECT}--${TARGET_CLUSTER}" >> ".env"
+else
+    printf "\e[33mEnter the machine class file path\e[0m\n"
+    read MACHINECLASS
+    if [ ! -f "$MACHINECLASS" ]
+    then
+        printf "\e[31m$MACHINECLASS is not a valid file path\e[0m\n"
+        exit 1
+    fi
+    printf "\e[33mDo you want to create the secret automatically ? (true/false)\e[0m\n"
+    printf "\e[33mNote: This is only possible if your control cluster is a gardener shoot.\e[0m\n"
+    read CREATE_SECRET
+    if [ -z "$CREATE_SECRET" ]
+    then
+        printf "\e[31mentered value cannot be empty\e[0m\n"
+        exit 1
+    fi
+    if [ "$CREATE_SECRET" != true ] && [ "$CREATE_SECRET" != false ]
+    then
+        printf "\e[31mentered value must be a boolean\e[0m\n"
+        exit 1
+    fi
+    if [ "$CREATE_SECRET" = false ]
+    then
+        printf "\e[33mEnter the absolute path for the secret to be applied.\e[0m\n"
+        read SECRET_PATH
+        if [ -z "$SECRET_PATH" ]
+        then
+            printf "\e[31mentered value cannot be empty\e[0m\n"
+            exit 1
+        fi
+        if [ ! -f "$SECRET_PATH" ]
+        then
+            printf "\e[31m$SECRET_PATH is not a valid file path\e[0m\n"
+            exit 1
+        fi
+    else
+      printf "\e[33mEnter the secret name present in the garden-core namespace that contains the infrastructure credentials.\e[0m\n"
+      printf "\e[33mNote: Default secret name is $DEFAULT_CREDENTIALS_SECRET_NAME. Press Enter to proceed with it.\e[0m\n"
+      read CREDENTIALS_SECRET_NAME
+      if [ -z "$CREDENTIALS_SECRET_NAME" ]
+      then
+          CREDENTIALS_SECRET_NAME="$DEFAULT_CREDENTIALS_SECRET_NAME"
+      fi
+    fi
+
+    printf "\e[33mEnter the namespace on which you want to operate in the control cluster\e[0m\n"
+    read NAMESPACE; \
+    if [ -z "$NAMESPACE" ]
+    then
+        printf "\e[31mentered value cannot be empty\e[0m\n"
+        exit 1
+    fi
+    printf "\e[33mEnter control kubeconfig path\e[0m\n";
+    read CONTROL_KUBECONFIG_PATH;
+    if [ ! -f "$CONTROL_KUBECONFIG_PATH" ]
+    then
+        printf "\e[31"$CONTROL_KUBECONFIG_PATH" is not a valid filepath\e[0m\n"
+        exit 1
+    fi
+    printf "\e[33mEnter target kubeconfig path\e[0m\n";
+    read TARGET_KUBECONFIG_PATH;
+    if [ ! -f "$TARGET_KUBECONFIG_PATH" ]
+    then
+        printf "\e[31"$TARGET_KUBECONFIG_PATH" is not a valid filepath\e[0m\n"
+        exit 1
+    fi
+    "$MCM_REPO_PATH"/hack/non_gardener_local_setup.sh --namespace $NAMESPACE --control-kubeconfig-path "$CONTROL_KUBECONFIG_PATH" --target-kubeconfig-path "$TARGET_KUBECONFIG_PATH" --provider "$PROVIDER"
+    printf "\n%s" "MACHINECLASS_V1=${MACHINECLASS}" >> ".env"
+    printf "\e[33mEnter the TARGET_CLUSTER_NAME. (Used for initializing orphan resource tracker)\e[0m\n"
+    read TARGET_CLUSTER_NAME
+    printf "\n%s" "TARGET_CLUSTER_NAME=${TARGET_CLUSTER_NAME}" >> ".env"
+fi
+
+set -o allexport
+source .env
+set +o allexport
+
+GARDEN_CORE_NAMESPACE=garden-core
+
+
+if [ "$IS_CONTROL_CLUSTER_SEED" = false ]
+then
+  if [ "$CREATE_SECRET" = true ]; then
+    create_test_mc_secret
+  else
+    kubectl apply --kubeconfig="$CONTROL_KUBECONFIG" -f "$SECRET_PATH"
+  fi
+
+fi
+
+printf "\e[33mStarting integration tests...\e[0m\n"
+
+cd test/integration/controller
+
+set +e
+ginkgo -v --show-node-events --poll-progress-after=300s --poll-progress-interval=60s
+set -e
+printf "\e[32mIntegration tests completed successfully\e[0m\n"
+
+if [ "$IS_CONTROL_CLUSTER_SEED" = false ]
+then
+    set +e
+    kubectl --kubeconfig=$CONTROL_KUBECONFIG delete secret test-mc-secret
+    set -e
+    printf "\e[32mSuccessfully deleted test-mc-secret on control cluster\e[0m\n"
+
+fi
+
+rm -f ../../../.env
+cd -

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 # Tools & Cleanup
 #########################################
 
-TOOLS_DIR := $(HACK_DIR)/tools
-include $(GARDENER_HACK_DIR)/tools.mk
+#TOOLS_DIR := $(HACK_DIR)/tools
+#include $(GARDENER_HACK_DIR)/tools.mk
 -include .env
 
 .PHONY: tidy
@@ -107,14 +107,6 @@ clean:
 
 .PHONY: test-integration
 test-integration:
-	@if [[ -f $(PWD)/$(CONTROL_KUBECONFIG) ]]; then export CONTROL_KUBECONFIG=$(PWD)/$(CONTROL_KUBECONFIG); elif [[ -f $(CONTROL_KUBECONFIG) ]]; then export CONTROL_KUBECONFIG=$(CONTROL_KUBECONFIG);else echo "No such file exists for CONTROL_KUBECONFIG";exit 1; fi; \
-	if [[ -f $(PWD)/$(TARGET_KUBECONFIG) ]]; then export TARGET_KUBECONFIG=$(PWD)/$(TARGET_KUBECONFIG); elif [[ -f $(TARGET_KUBECONFIG) ]]; then export TARGET_KUBECONFIG=$(TARGET_KUBECONFIG);else echo "No such file exists for TARGET_KUBECONFIG";exit 1; fi; \
-	if [[ -f "$(PWD)/$(MACHINECLASS_V1)" ]]; then export MACHINECLASS_V1="$(PWD)/$(MACHINECLASS_V1)"; elif [[ -f "$(MACHINECLASS_V1)" ]]; then export MACHINECLASS_V1="$(MACHINECLASS_V1)"; fi; \
-	if [[ -f "$(PWD)/$(MACHINECLASS_V2)" ]]; then export MACHINECLASS_V2="$(PWD)/$(MACHINECLASS_V2)"; elif [[ -f "$(MACHINECLASS_V2)" ]]; then export MACHINECLASS_V2="$(MACHINECLASS_V2)"; fi; \
-	export MC_CONTAINER_IMAGE=$(MC_IMAGE); \
-	export MCM_CONTAINER_IMAGE=$(MCM_IMAGE); \
-	export CONTROL_CLUSTER_NAMESPACE=$(CONTROL_NAMESPACE); \
-	export MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME=$(MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME); \
 	.ci/local_integration_test
 
 #########################################

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 # Tools & Cleanup
 #########################################
 
-#TOOLS_DIR := $(HACK_DIR)/tools
-#include $(GARDENER_HACK_DIR)/tools.mk
+TOOLS_DIR := $(HACK_DIR)/tools
+include $(GARDENER_HACK_DIR)/tools.mk
 -include .env
 
 .PHONY: tidy


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/platform openstack

**What this PR does / why we need it**:
This PR modifies the IT test make target to incorporate shoot as a seed setup as well as seed setup for local IT.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
