### PR TITLE
fixes docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,10 @@ test-integration:
 .PHONY: release
 release: docker-image docker-push
 
-platform ?= linux/amd64
+PLATFORM ?= linux/amd64
 .PHONY: docker-image
 docker-image:
-	@docker buildx build --platform $(platform) -t $(IMAGE_NAME):$(VERSION) -t $(IMAGE_NAME):latest .
+	@docker buildx build --platform $(PLATFORM) -t $(IMAGE_NAME):$(VERSION) -t $(IMAGE_NAME):latest .
 
 .PHONY: docker-login
 docker-login:

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,6 @@ release: docker-image docker-push
 platform ?= linux/amd64
 .PHONY: docker-image
 docker-image:
-	@echo $(GARDENER_HACK_DIR)
 	@docker buildx build --platform $(platform) -t $(IMAGE_NAME):$(VERSION) -t $(IMAGE_NAME):latest .
 
 .PHONY: docker-login

--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,11 @@ test-integration:
 .PHONY: release
 release: docker-image docker-push
 
+platform ?= linux/amd64
 .PHONY: docker-image
 docker-image:
-	docker image build -t $(IMAGE_NAME):$(VERSION) -t $(IMAGE_NAME):latest .
+	@echo $(GARDENER_HACK_DIR)
+	@docker buildx build --platform $(platform) -t $(IMAGE_NAME):$(VERSION) -t $(IMAGE_NAME):latest .
 
 .PHONY: docker-login
 docker-login:


### PR DESCRIPTION
**How to categorize this PR?**
This PR provides a flag to specify target platform for the docker image

<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/machine-controller-manager/issues/921

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
