### PR TITLE
Fix templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -18,7 +18,7 @@ If multiple identifiers make sense you can also state the commands multiple time
 -->
 /area TODO
 /kind bug
-/platform aws
+/platform openstack
 
 **What happened**:
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -18,7 +18,7 @@ If multiple identifiers make sense you can also state the commands multiple time
 -->
 /area TODO
 /kind enhancement
-/platform aws
+/platform openstack
 
 **What would you like to be added**:
 

--- a/.github/ISSUE_TEMPLATE/flaking-test.md
+++ b/.github/ISSUE_TEMPLATE/flaking-test.md
@@ -21,7 +21,7 @@ If multiple identifiers make sense you can also state the commands multiple time
 -->
 /area testing
 /kind flake
-/platform aws
+/platform openstack
 
 **Which test(s)/suite(s) are flaking**:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ For Gardener Enhancement Proposals (GEPs), please check the following [documenta
 -->
 /area TODO
 /kind TODO
-/platform aws
+/platform openstack
 
 **What this PR does / why we need it**:
 

--- a/hack/update-github-templates.sh
+++ b/hack/update-github-templates.sh
@@ -16,6 +16,6 @@ for file in `find "${GARDENER_HACK_DIR}"/../.github -name '*.md'`; do
     sed 's/to the Gardener project/for this extension/g' |\
     sed 's/to Gardener/to this extension/g' |\
     sed 's/- Gardener version:/- Gardener version (if relevant):\n- Extension version:/g' |\
-    sed 's/\/kind [a-zA-Z]*/&\n\/platform aws/g' \
+    sed 's/\/kind [a-zA-Z]*/&\n\/platform openstack/g' \
   > "$(dirname $0)/../.github/${file#*.github/}"
 done


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug
/platform openstack

**What this PR does / why we need it**:
The /platform field in the repository templates for issues and PRs was wrongly set to aws and should be switched to openstack.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Set repository PR template /platform from aws to openstack
```
