### PR TITLE
fix issue with gg 1.103 with pod network being a slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ LEADER_ELECT 	    := "true"
 # If Integration Test Suite is to be run locally against clusters then export the below variable
 # with MCM deployment name in the cluster
 MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
+PLATFORM ?= linux/amd64
 
 #########################################
 # Tools & Cleanup
@@ -116,7 +117,6 @@ test-integration:
 .PHONY: release
 release: docker-image docker-push
 
-PLATFORM ?= linux/amd64
 .PHONY: docker-image
 docker-image:
 	@docker buildx build --platform $(PLATFORM) -t $(IMAGE_NAME):$(VERSION) -t $(IMAGE_NAME):latest .

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -156,7 +156,21 @@ string
 </em>
 </td>
 <td>
-<p>PodNetworkCidr is the CIDR range for the pods assigned to this instance.</p>
+<em>(Optional)</em>
+<p>PodNetworkCidr is the CIDR range for the pods assigned to this instance.
+Deprecated: use PodNetworkCIDRs instead</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podNetworkCIDRs</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PodNetworkCIDRs is the CIDR ranges for the pods assigned to this instance.</p>
 </td>
 </tr>
 <tr>
@@ -360,7 +374,21 @@ string
 </em>
 </td>
 <td>
-<p>PodNetworkCidr is the CIDR range for the pods assigned to this instance.</p>
+<em>(Optional)</em>
+<p>PodNetworkCidr is the CIDR range for the pods assigned to this instance.
+Deprecated: use PodNetworkCIDRs instead</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podNetworkCIDRs</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PodNetworkCIDRs is the CIDR ranges for the pods assigned to this instance.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/openstack/types.go
+++ b/pkg/apis/openstack/types.go
@@ -40,7 +40,10 @@ type MachineProviderConfigSpec struct {
 	// SubnetID is the ID of the subnet the instance should belong to. If SubnetID is not specified
 	SubnetID *string
 	// PodNetworkCidr is the CIDR range for the pods assigned to this instance.
+	// Deprecated - use `PodNetworkCIDRs` instead.
 	PodNetworkCidr string
+	// PodNetworkCidr is the CIDR ranges for the pods assigned to this instance.
+	PodNetworkCIDRs []string
 	// The size of the root disk used for the instance.
 	RootDiskSize int
 	// The type of the root disk type used for the instance

--- a/pkg/apis/openstack/v1alpha1/types.go
+++ b/pkg/apis/openstack/v1alpha1/types.go
@@ -43,7 +43,12 @@ type MachineProviderConfigSpec struct {
 	// +optional
 	SubnetID *string `json:"subnetID,omitempty"`
 	// PodNetworkCidr is the CIDR range for the pods assigned to this instance.
+	// Deprecated: use PodNetworkCIDRs instead
+	// +optional
 	PodNetworkCidr string `json:"podNetworkCidr"`
+	// PodNetworkCIDRs is the CIDR ranges for the pods assigned to this instance.
+	// +optional
+	PodNetworkCIDRs []string `json:"podNetworkCIDRs"`
 	// The size of the root disk used for the instance.
 	RootDiskSize int `json:"rootDiskSize,omitempty"` // in GB
 	// The type of the root disk used for the instance.

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -93,6 +93,7 @@ func autoConvert_v1alpha1_MachineProviderConfigSpec_To_openstack_MachineProvider
 	out.NetworkID = in.NetworkID
 	out.SubnetID = (*string)(unsafe.Pointer(in.SubnetID))
 	out.PodNetworkCidr = in.PodNetworkCidr
+	out.PodNetworkCIDRs = *(*[]string)(unsafe.Pointer(&in.PodNetworkCIDRs))
 	out.RootDiskSize = in.RootDiskSize
 	out.RootDiskType = (*string)(unsafe.Pointer(in.RootDiskType))
 	out.UseConfigDrive = (*bool)(unsafe.Pointer(in.UseConfigDrive))
@@ -118,6 +119,7 @@ func autoConvert_openstack_MachineProviderConfigSpec_To_v1alpha1_MachineProvider
 	out.NetworkID = in.NetworkID
 	out.SubnetID = (*string)(unsafe.Pointer(in.SubnetID))
 	out.PodNetworkCidr = in.PodNetworkCidr
+	out.PodNetworkCIDRs = *(*[]string)(unsafe.Pointer(&in.PodNetworkCIDRs))
 	out.RootDiskSize = in.RootDiskSize
 	out.RootDiskType = (*string)(unsafe.Pointer(in.RootDiskType))
 	out.UseConfigDrive = (*bool)(unsafe.Pointer(in.UseConfigDrive))

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -59,6 +59,11 @@ func (in *MachineProviderConfigSpec) DeepCopyInto(out *MachineProviderConfigSpec
 		*out = new(string)
 		**out = **in
 	}
+	if in.PodNetworkCIDRs != nil {
+		in, out := &in.PodNetworkCIDRs, &out.PodNetworkCIDRs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.RootDiskType != nil {
 		in, out := &in.RootDiskType, &out.RootDiskType
 		*out = new(string)

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -59,6 +59,11 @@ func (in *MachineProviderConfigSpec) DeepCopyInto(out *MachineProviderConfigSpec
 		*out = new(string)
 		**out = **in
 	}
+	if in.PodNetworkCIDRs != nil {
+		in, out := &in.PodNetworkCIDRs, &out.PodNetworkCIDRs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.RootDiskType != nil {
 		in, out := &in.RootDiskType, &out.RootDiskType
 		*out = new(string)

--- a/pkg/apis/validation/validation_test.go
+++ b/pkg/apis/validation/validation_test.go
@@ -36,13 +36,13 @@ var _ = Describe("Validation", func() {
 						fmt.Sprintf("%s-foo", ServerTagRolePrefix):    "1",
 						fmt.Sprintf("%s-foo", ServerTagClusterPrefix): "1",
 					},
-					NetworkID:      "networkID",
-					SubnetID:       nil,
-					PodNetworkCidr: "10.0.0.1/8",
-					RootDiskSize:   0,
-					UseConfigDrive: nil,
-					ServerGroupID:  nil,
-					Networks:       nil,
+					NetworkID:       "networkID",
+					SubnetID:        nil,
+					PodNetworkCIDRs: []string{"10.0.0.1/8"},
+					RootDiskSize:    0,
+					UseConfigDrive:  nil,
+					ServerGroupID:   nil,
+					Networks:        nil,
 				},
 			}
 		})
@@ -59,7 +59,7 @@ var _ = Describe("Validation", func() {
 				spec.FlavorName = ""
 				spec.AvailabilityZone = ""
 				spec.KeyName = ""
-				spec.PodNetworkCidr = ""
+				spec.PodNetworkCIDRs = nil
 				err := validateMachineProviderConfig(machineProviderConfig)
 
 				Expect(err).To(ConsistOf(
@@ -81,7 +81,7 @@ var _ = Describe("Validation", func() {
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  BeEquivalentTo("FieldValueRequired"),
-						"Field": Equal("spec.podNetworkCidr"),
+						"Field": Equal("spec.PodNetworkCIDRs"),
 					})),
 				))
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area conrol-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:

Necessary to create machines after https://github.com/gardener/gardener-extension-provider-openstack/pull/850

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow input of pod CIDRs as slice.
```
