### PR TITLE
increase server status timeouts

### DIFF
--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -95,7 +95,7 @@ func (ex *Executor) CreateMachine(ctx context.Context, machineName string, userD
 		}
 	}
 
-	err = ex.waitForServerStatus(ctx, server.ID, []string{client.ServerStatusBuild}, []string{client.ServerStatusActive}, 600)
+	err = ex.waitForServerStatus(ctx, server.ID, []string{client.ServerStatusBuild}, []string{client.ServerStatusActive}, 1200)
 	if err != nil {
 		return "", deleteOnFail(fmt.Errorf("error waiting for server [ID=%q] to reach target status: %w", server.ID, err))
 	}
@@ -325,7 +325,7 @@ func (ex *Executor) ensureVolume(ctx context.Context, name, imageID string) (str
 
 	pendingStatuses := []string{client.VolumeStatusCreating, client.VolumeStatusDownloading}
 	targetStatuses := []string{client.VolumeStatusAvailable}
-	if err := ex.waitForVolumeStatus(ctx, volumeID, pendingStatuses, targetStatuses, 600); err != nil {
+	if err := ex.waitForVolumeStatus(ctx, volumeID, pendingStatuses, targetStatuses, 1200); err != nil {
 		return "", err
 	}
 
@@ -471,7 +471,7 @@ func (ex *Executor) DeleteMachine(ctx context.Context, machineName, providerID s
 			return err
 		}
 
-		if err = ex.waitForServerStatus(ctx, server.ID, nil, []string{client.ServerStatusDeleted}, 300); err != nil {
+		if err = ex.waitForServerStatus(ctx, server.ID, nil, []string{client.ServerStatusDeleted}, 1200); err != nil {
 			return fmt.Errorf("error while waiting for server [ID=%q] to be deleted: %v", server.ID, err)
 		}
 	} else if !errors.Is(err, ErrNotFound) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression
/platform openstack

**What this PR does / why we need it**:

Increase timeout of server status checks 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increase VM status check timeout to 1200 seconds.
```
