### PR TITLE
fix: no valid host found detection string

### DIFF
--- a/pkg/driver/executor/errors.go
+++ b/pkg/driver/executor/errors.go
@@ -9,7 +9,11 @@ import (
 )
 
 // NoValidHost is a part of the error message returned when there is no valid host in the zone to deploy a VM.
-const NoValidHost = "not enough hosts available"
+// Matches:
+//
+//	"No valid host was found."
+//	"No valid host was found. There are not enough hosts available."
+const NoValidHost = "No valid host was found"
 
 var (
 	// ErrNotFound is returned when the requested resource could not be found.


### PR DESCRIPTION
**How to categorize this PR?**
/area usability
/kind bug
/platform openstack

**What this PR does / why we need it**:
The previous string used to determine if there is a `ResourceExhausted` error did not cover all possible cases.

Additionally, to the `No valid host was found. There are not enough hosts available.` error, we also see cases where on `No valid host was found.` is being returned.