### PR TITLE
[rel-v0.24] Cherry pick 324 and 311

### DIFF
--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,7 +1,7 @@
 componentReferences:
 - componentName: github.com/gardener/machine-controller-manager
   name: machine-controller-manager
-  version: v0.60.0
+  version: v0.60.1
 main-source:
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1

--- a/.ocm/release-notes/github.com_gardener_machine-controller-manager_v0.60.1.release-notes.yaml
+++ b/.ocm/release-notes/github.com_gardener_machine-controller-manager_v0.60.1.release-notes.yaml
@@ -1,0 +1,15 @@
+ocm:
+  component_name: github.com/gardener/machine-controller-manager
+  component_version: v0.60.1
+release_notes:
+- audience: operator
+  author:
+    hostname: github.com
+    type: githubUser
+    username: takoverflow
+  category: bugfix
+  contents: Added a safeguard to delay deletion of machines that are undergoing a
+    `Create` Request to prevent orphaning of VMs.
+  mimetype: text/markdown
+  reference: '[#1045](https://github.com/gardener/machine-controller-manager/pull/1045)'
+  type: standard

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
 	github.com/gardener/gardener v1.127.0
-	github.com/gardener/machine-controller-manager v0.60.0
+	github.com/gardener/machine-controller-manager v0.60.1
 	github.com/gophercloud/gophercloud/v2 v2.8.0
 	github.com/onsi/ginkgo/v2 v2.25.2
 	github.com/onsi/gomega v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vt
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gardener/gardener v1.127.0 h1:vp0j/QhU4xlnIetsNnvNOeuR2bNg7Q9KgOoHoWFz2Sk=
 github.com/gardener/gardener v1.127.0/go.mod h1:OQBZdCX82NxFs3N2w94YyOXWRZDqzo/W0PGj7QevMvQ=
-github.com/gardener/machine-controller-manager v0.60.0 h1:aaSE85Yu0hcHYsP5/x1rxWa5o2zhmsmXlKQ+xefHY/Q=
-github.com/gardener/machine-controller-manager v0.60.0/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
+github.com/gardener/machine-controller-manager v0.60.1 h1:+kcTIM2LkGDkL4KA1zhHPgnnt7idAYL0fw0RtnIwlg4=
+github.com/gardener/machine-controller-manager v0.60.1/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/platform openstack

**What this PR does / why we need it**:
This PR cherry picks the following commits 
1. https://github.com/gardener/machine-controller-manager-provider-openstack/commit/632a79257938d3c002172db91e9e95edb71cec45
2. https://github.com/gardener/machine-controller-manager-provider-openstack/commit/7b7c449db095015c0b3601f630961b5a567671c2

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Upgrade dependency gardener/machine-controller-manager from v0.60.0 to v0.60.1
```
