### PR TITLE
feat: Implement optional driver GetMachineStatus method

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -149,7 +149,7 @@ func (p *OpenstackDriver) GetMachineStatus(ctx context.Context, req *driver.GetM
 	// Finding by ProviderID should be the common path, by name fallback for pre-creation
 	if req.Machine.Spec.ProviderID != "" {
 		klog.V(2).Infof("Finding Machine (%q) by ProviderID: %q", req.Machine.Name, req.Machine.Spec.ProviderID)
-		machine, err = ex.GetMachineByID(ctx, req.Machine.Spec.ProviderID)
+		machine, err = ex.GetMachineByProviderID(ctx, req.Machine.Spec.ProviderID)
 	} else {
 		klog.V(2).Infof("Finding Machine by Tags and Name: %q", req.Machine.Name)
 		machine, err = ex.GetMachineByName(ctx, req.Machine.Name)

--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -510,7 +510,7 @@ func (ex *Executor) DeleteMachine(ctx context.Context, machineName, providerID s
 	)
 
 	if !isEmptyString(ptr.To(providerID)) {
-		server, err = ex.GetMachineByID(ctx, providerID)
+		server, err = ex.GetMachineByProviderID(ctx, providerID)
 	} else {
 		server, err = ex.GetMachineByName(ctx, machineName)
 	}
@@ -639,8 +639,8 @@ func (ex *Executor) deleteVolume(ctx context.Context, machineName string) error 
 	return nil
 }
 
-// GetMachineByID fetches the data for a server based on a provider-encoded ID.
-func (ex *Executor) GetMachineByID(ctx context.Context, providerID string) (*servers.Server, error) {
+// GetMachineByProviderID fetches the data for a server based on a provider-encoded ID.
+func (ex *Executor) GetMachineByProviderID(ctx context.Context, providerID string) (*servers.Server, error) {
 	klog.V(2).Infof("finding server with [ID=%q]", providerID)
 	serverID := decodeProviderID(providerID)
 	server, err := ex.Compute.GetServer(ctx, serverID)

--- a/pkg/driver/executor/executor_test.go
+++ b/pkg/driver/executor/executor_test.go
@@ -417,7 +417,7 @@ var _ = Describe("Executor", func() {
 
 				setupMocks()
 
-				server, err := ex.GetMachineByID(ctx, providerID)
+				server, err := ex.GetMachineByProviderID(ctx, providerID)
 				if expectedErr != nil {
 					Expect(err).To(HaveOccurred())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

This PR implements the GetMachineStatus method of the mcm-provider-openstack, which is optional as per the [Machine Error code handling](https://github.com/gardener/machine-controller-manager/blob/master/docs/development/machine_error_codes.md) (but which is implemented for other providers like aws or gcp). 

Working on GEP-28 (self-hosted shoots, managed infra scenario) we noticed that the control plane worker node never became ready due to the logic in the mcm not adding the required node label on the Machine objects. Would the GetMachineStatus have been implemented it would have done so. As the implementation is optional, [@maboehm](https://github.com/maboehm) implemented a fix in the [gardener/machine-controller-manager#1050](https://github.com/gardener/machine-controller-manager/pull/1050) itself. The implementation of the `GetMachineStatus` is now more of a "nice to have" which could potentially reduce some loads on the OpenStack API Server by doing a lookup by provider ID first if provided and then by name instead of having to call `Create` of the driver which has to fetch the list of all Servers in the project every time.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Tested in Self-hosted Managed infrastructure flow. Requires running e2e.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Implement the optional GetMachineStatus driver method
```
