### PR TITLE
Fix nil dereference of SubnetID when only SubnetIDs is configured

### DIFF
--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -170,12 +170,17 @@ func (ex *Executor) resolveServerNetworks(ctx context.Context, machineName strin
 	klog.V(3).Infof("resolving network setup for machine [Name=%q]", machineName)
 	// If SubnetID is specified in addition to NetworkID, we have to preallocate a Neutron Port to force the VMs to get IP from the subnet's range.
 	if ex.isUserManagedNetwork() {
-		// check if the subnet exists
-		if _, err := ex.Network.GetSubnet(ctx, *subnetID); err != nil {
-			return nil, err
+		// check that all subnets exist upfront
+		if subnetID != nil {
+			if _, err := ex.Network.GetSubnet(ctx, *subnetID); err != nil {
+				return nil, fmt.Errorf("subnet [ID=%q] not found: %w", *subnetID, err)
+			}
 		}
-
-		klog.V(3).Infof("deploying machine [Name=%q] in subnet [ID=%q]", machineName, *subnetID)
+		for _, id := range ex.Config.Spec.SubnetIDs {
+			if _, err := ex.Network.GetSubnet(ctx, id); err != nil {
+				return nil, fmt.Errorf("subnet [ID=%q] from SubnetIDs not found: %w", id, err)
+			}
+		}
 		portID, err := ex.getOrCreatePort(ctx, machineName)
 		if err != nil {
 			return nil, err

--- a/pkg/driver/executor/executor_test.go
+++ b/pkg/driver/executor/executor_test.go
@@ -168,6 +168,40 @@ var _ = Describe("Executor", func() {
 			Expect(server.ProviderID).To(Equal(encodeProviderID(region, serverID)))
 		})
 
+		It("should succeed when spec contains SubnetIDs only", func() {
+			subnetID1 := "subnetID1"
+			subnetID2 := "subnetID2"
+
+			cfg.Spec.SubnetIDs = []string{subnetID1, subnetID2}
+			ex := &Executor{
+				Compute: compute,
+				Network: network,
+				Config:  cfg,
+			}
+
+			compute.EXPECT().ListServers(ctx, &servers.ListOpts{Name: machineName}).Return([]servers.Server{}, nil)
+			network.EXPECT().GetSubnet(ctx, subnetID1).Return(&subnets.Subnet{}, nil)
+			network.EXPECT().GetSubnet(ctx, subnetID2).Return(&subnets.Subnet{}, nil)
+			network.EXPECT().PortIDFromName(ctx, machineName).Return("", gophercloud.ErrResourceNotFound{})
+			network.EXPECT().CreatePort(ctx, gomock.Any()).Return(&ports.Port{ID: portID, Name: machineName}, nil)
+			network.EXPECT().TagPort(ctx, gomock.Any(), gomock.Any()).Return(nil)
+			compute.EXPECT().ImageIDFromName(ctx, imageName).Return(images.Image{ID: "imageID"}, nil)
+			compute.EXPECT().FlavorIDFromName(ctx, flavorName).Return("flavorID", nil)
+			compute.EXPECT().CreateServer(ctx, gomock.Any(), gomock.Any()).Return(&servers.Server{ID: serverID}, nil)
+			gomock.InOrder(
+				compute.EXPECT().GetServer(ctx, serverID).Return(&servers.Server{ID: serverID, Status: client.ServerStatusBuild}, nil),
+				compute.EXPECT().GetServer(ctx, serverID).Return(&servers.Server{ID: serverID, Status: client.ServerStatusActive}, nil),
+			)
+			network.EXPECT().ListPorts(ctx, &ports.ListOpts{DeviceID: serverID}).Return([]ports.Port{{NetworkID: networkID, ID: portID}}, nil)
+			network.EXPECT().UpdatePort(ctx, portID, ports.UpdateOpts{
+				AllowedAddressPairs: &[]ports.AddressPair{{IPAddress: podCidr}},
+			}).Return(nil)
+
+			server, err := ex.CreateMachine(ctx, machineName, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(server.ProviderID).To(Equal(encodeProviderID(region, serverID)))
+		})
+
 		It("should succeed when spec contains rootDisksize", func() {
 			var (
 				diskType = "standard_hdd"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform openstack

**What this PR does / why we need it**:
Fix nil panic in resolveServerNetworks and validate SubnetIDs upfront.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix panic during machine creation when SubnetIDs is configured without SubnetID.
```
