### PR TITLE
Feature: Map flavor not found to ResourceExhausted grpc code

### DIFF
--- a/pkg/driver/executor/errors.go
+++ b/pkg/driver/executor/errors.go
@@ -8,12 +8,17 @@ import (
 	"fmt"
 )
 
-// NoValidHost is a part of the error message returned when there is no valid host in the zone to deploy a VM.
-// Matches:
-//
-//	"No valid host was found."
-//	"No valid host was found. There are not enough hosts available."
-const NoValidHost = "No valid host was found"
+const (
+	// NoValidHost is a part of the error message returned when there is no valid host in the zone to deploy a VM.
+	// Matches:
+	//
+	//	"No valid host was found."
+	//	"No valid host was found. There are not enough hosts available."
+	NoValidHost = "No valid host was found"
+
+	// FlavorNotFound is part of the error message returned when a flavor cannot be resolved.
+	FlavorNotFound = "error resolving flavor"
+)
 
 var (
 	// ErrNotFound is returned when the requested resource could not be found.

--- a/pkg/driver/executor/errors.go
+++ b/pkg/driver/executor/errors.go
@@ -17,6 +17,10 @@ const (
 	NoValidHost = "No valid host was found"
 
 	// FlavorNotFound is part of the error message returned when a flavor cannot be resolved.
+	// This string-matching fallback is needed because FlavourIDFromName (from executor.go deployServer)
+	// only wraps the typed ErrFlavorNotFound when the undelying gophercloud error is gophercloud.ErrResourceNotFound.
+	// If gophercloud returns any other error type, the typed-error path in mapErrorToCode will not match, and
+	// we fall back to inspecting the error message here so the failure is still  classified as codes.ResourceExhausted.
 	FlavorNotFound = "error resolving flavor"
 )
 

--- a/pkg/driver/executor/errors.go
+++ b/pkg/driver/executor/errors.go
@@ -17,7 +17,7 @@ const (
 	NoValidHost = "No valid host was found"
 
 	// FlavorNotFound is part of the error message returned when a flavor cannot be resolved.
-	// This string-matching fallback is needed because FlavourIDFromName (from executor.go deployServer)
+	// This string-matching fallback is needed because FlavorIDFromName (from executor.go deployServer)
 	// only wraps the typed ErrFlavorNotFound when the underlying gophercloud error is gophercloud.ErrResourceNotFound.
 	// If gophercloud returns any other error type, the typed-error path in mapErrorToCode will not match, and
 	// we fall back to inspecting the error message here so the failure is still classified as codes.ResourceExhausted.

--- a/pkg/driver/executor/errors.go
+++ b/pkg/driver/executor/errors.go
@@ -18,9 +18,9 @@ const (
 
 	// FlavorNotFound is part of the error message returned when a flavor cannot be resolved.
 	// This string-matching fallback is needed because FlavourIDFromName (from executor.go deployServer)
-	// only wraps the typed ErrFlavorNotFound when the undelying gophercloud error is gophercloud.ErrResourceNotFound.
+	// only wraps the typed ErrFlavorNotFound when the underlying gophercloud error is gophercloud.ErrResourceNotFound.
 	// If gophercloud returns any other error type, the typed-error path in mapErrorToCode will not match, and
-	// we fall back to inspecting the error message here so the failure is still  classified as codes.ResourceExhausted.
+	// we fall back to inspecting the error message here so the failure is still classified as codes.ResourceExhausted.
 	FlavorNotFound = "error resolving flavor"
 )
 

--- a/pkg/driver/utils.go
+++ b/pkg/driver/utils.go
@@ -72,7 +72,7 @@ func mapErrorToCode(err error) codes.Code {
 
 func mapErrorMessageToCode(err error) codes.Code {
 	errorMessage := err.Error()
-	if strings.Contains(errorMessage, executor.NoValidHost) {
+	if strings.Contains(errorMessage, executor.NoValidHost) || strings.Contains(errorMessage, executor.FlavorNotFound) {
 		return codes.ResourceExhausted
 	}
 	return codes.Internal

--- a/pkg/driver/utils_test.go
+++ b/pkg/driver/utils_test.go
@@ -61,5 +61,12 @@ var _ = Describe("Utils", func() {
 			Expect(err2).To(HaveOccurred())
 			Expect(mapErrorToCode(err1)).To(Equal(codes.Internal))
 		})
+		It("should map error containing executor.FlavorNotFoundto ResourceExhausted error code", func() {
+			err1 := fmt.Errorf("error: %s", executor.FlavorNotFound)
+			err2 := status.Error(mapErrorToCode(err1), err1.Error())
+			Expect(err1).To(HaveOccurred())
+			Expect(err2).To(HaveOccurred())
+			Expect(mapErrorToCode(err1)).To(Equal(codes.ResourceExhausted))
+		})
 	})
 })

--- a/pkg/driver/utils_test.go
+++ b/pkg/driver/utils_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Utils", func() {
 			Expect(err2).To(HaveOccurred())
 			Expect(mapErrorToCode(err1)).To(Equal(codes.Internal))
 		})
-		It("should map error containing executor.FlavorNotFoundto ResourceExhausted error code", func() {
+		It("should map error containing executor.FlavorNotFound to ResourceExhausted error code", func() {
 			err1 := fmt.Errorf("error: %s", executor.FlavorNotFound)
 			err2 := status.Error(mapErrorToCode(err1), err1.Error())
 			Expect(err1).To(HaveOccurred())


### PR DESCRIPTION
**How to categorize this PR?**
/area robustness
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
This PR improves OpenStack machine error handling by classifying flavor resolution failures and mapping them to `codes.ResourceExhausted`. Previously, only `NoValidHost` errors were classified as resource exhausted errors.

**Special notes for your reviewer**:
None

**Release note**:
```other operator
Improved OpenStack machine error handling by classifying flavor resolution failure as resource exhaustion.
```
