### PR TITLE
Add support for additional authentication options in factory.go

### DIFF
--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -64,8 +64,12 @@ func newAuthenticatedProviderClientFromCredentials(ctx context.Context, credenti
 
 	if credentials.ApplicationCredentialID != "" {
 		authOpts.ApplicationCredentialID = credentials.ApplicationCredentialID
+		authOpts.ApplicationCredentialSecret = credentials.ApplicationCredentialSecret
+	} else if credentials.ApplicationCredentialName != "" {
 		authOpts.ApplicationCredentialName = credentials.ApplicationCredentialName
 		authOpts.ApplicationCredentialSecret = credentials.ApplicationCredentialSecret
+		authOpts.Username = credentials.Username
+		authOpts.DomainName = credentials.DomainName
 	} else {
 		authOpts.Username = credentials.Username
 		authOpts.Password = credentials.Password


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug
/platform openstack

**What this PR does / why we need it**:
This PR fixes the authentication with credentialName like in this PR for the extension: https://github.com/gardener/gardener-extension-provider-openstack/pull/1081/changes.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/machine-controller-manager-provider-openstack/issues/394

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Enable appCredential authentication using AppName
```
