### PR TITLE
Upgrade github.com/gardener/machine-controller-manager (#398)

### DIFF
--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,7 +1,7 @@
 componentReferences:
 - componentName: github.com/gardener/machine-controller-manager
   name: machine-controller-manager
-  version: v0.62.0
+  version: v0.62.1
 main-source:
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1

--- a/.ocm/release-notes/github.com_gardener_machine-controller-manager_v0.62.1.release-notes.yaml
+++ b/.ocm/release-notes/github.com_gardener_machine-controller-manager_v0.62.1.release-notes.yaml
@@ -1,0 +1,17 @@
+ocm:
+  component_name: github.com/gardener/machine-controller-manager
+  component_version: v0.62.1
+release_notes:
+- audience: operator
+  author:
+    hostname: github.com
+    type: githubUser
+    username: thiyyakat
+  category: bugfix
+  contents: Fix preservation reconcile loop to avoid unconditionally uncordoning nodes
+    unrelated to machine preservation, prevent spurious writes on non-preserved machines,
+    and eliminate conflict errors caused by stale machine object comparison in the
+    defer annotation sync.
+  mimetype: text/markdown
+  reference: '[#1111](https://github.com/gardener/machine-controller-manager/pull/1111)'
+  type: standard

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/elastic/crd-ref-docs v0.3.0
 	github.com/gardener/gardener v1.142.0
 	github.com/gardener/gardener/pkg/apis v1.142.0
-	github.com/gardener/machine-controller-manager v0.62.0
+	github.com/gardener/machine-controller-manager v0.62.1
 	github.com/gophercloud/gophercloud/v2 v2.12.0
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/gardener/gardener v1.142.0 h1:9Q4TREbR/17KRdcMBCJtEoIizjMa7Ojx8W0PVVX
 github.com/gardener/gardener v1.142.0/go.mod h1:nPSTV5LDL//ZecYh5ju/Pt56LXJ1kQZt0TFVF1ZAux4=
 github.com/gardener/gardener/pkg/apis v1.142.0 h1:BfvNrLa0o6O01gTq1ew2kKcBs7H6xetM8hV7eKlNCHY=
 github.com/gardener/gardener/pkg/apis v1.142.0/go.mod h1:oN2NXhb68BCwMS8DHlVHZeGA88IUtjtCpMT1DapNN5o=
-github.com/gardener/machine-controller-manager v0.62.0 h1:XZWjAsXlNVj3S7M0AXcLkhNDGRRNm3Tc6ZFlTPPy3sc=
-github.com/gardener/machine-controller-manager v0.62.0/go.mod h1:ICsymXK4VHm7NVr8Mpl6USvYcTZjUNSk6+XaVu/dd74=
+github.com/gardener/machine-controller-manager v0.62.1 h1:TQ4Qs9aaYTqSkqFownIaEAvnrYoNpBMcp7ZMYVEgUWM=
+github.com/gardener/machine-controller-manager v0.62.1/go.mod h1:ICsymXK4VHm7NVr8Mpl6USvYcTZjUNSk6+XaVu/dd74=
 github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
 github.com/gkampitakis/ciinfo v0.3.2/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=


### PR DESCRIPTION
from v0.62.0 to v0.62.1

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug
/platform openstack

**What this PR does / why we need it**:
This PR cherry-picks commits from #398 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
