### PR TITLE
Implement GetMachineStatus

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -145,12 +145,46 @@ func (p *OpenstackDriver) DeleteMachine(ctx context.Context, req *driver.DeleteM
 }
 
 // GetMachineStatus handles a machine get status request
-func (p *OpenstackDriver) GetMachineStatus(_ context.Context, req *driver.GetMachineStatusRequest) (*driver.GetMachineStatusResponse, error) {
-	// Log messages to track start and end of request
+func (p *OpenstackDriver) GetMachineStatus(ctx context.Context, req *driver.GetMachineStatusRequest) (*driver.GetMachineStatusResponse, error) {
 	klog.V(2).Infof("GetMachineStatus request has been received for %q", req.Machine.Name)
-	defer klog.V(2).Infof("GetMachineStatus is not implemented")
+	defer klog.V(2).Infof("GetMachineStatus request has been processed for %q", req.Machine.Name)
 
-	return nil, status.Error(codes.Unimplemented, "method not implemented")
+	if req.MachineClass.Provider != openstackProvider {
+		err := fmt.Errorf("requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, openstackProvider)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if req.Machine.Spec.ProviderID == "" {
+		return nil, status.Error(codes.NotFound, fmt.Sprintf("machine %q has no providerID", req.Machine.Name))
+	}
+
+	providerConfig, err := p.decodeProviderSpec(req.MachineClass.ProviderSpec)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	if err := validation.ValidateRequest(providerConfig, req.Secret); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	factory, err := client.NewFactoryFromSecret(ctx, req.Secret)
+	if err != nil {
+		return nil, status.Error(mapErrorToCode(err), fmt.Sprintf("failed to construct OpenStack client: %v", err))
+	}
+
+	ex, err := executor.NewExecutor(factory, providerConfig)
+	if err != nil {
+		return nil, status.Error(mapErrorToCode(err), fmt.Sprintf("failed to construct executor: %v", err))
+	}
+
+	serverID := executor.DecodeProviderID(req.Machine.Spec.ProviderID)
+	if _, err = ex.GetMachineByID(ctx, serverID); err != nil {
+		return nil, status.Error(mapErrorToCode(err), err.Error())
+	}
+
+	return &driver.GetMachineStatusResponse{
+		ProviderID: req.Machine.Spec.ProviderID,
+		NodeName:   req.Machine.Name,
+	}, nil
 }
 
 // ListMachines lists all the machines possibly created by a providerSpec

--- a/pkg/driver/executor/executor.go
+++ b/pkg/driver/executor/executor.go
@@ -521,8 +521,8 @@ func (ex *Executor) DeleteMachine(ctx context.Context, machineName, providerID s
 	)
 
 	if !isEmptyString(ptr.To(providerID)) {
-		serverID := decodeProviderID(providerID)
-		server, err = ex.getMachineByID(ctx, serverID)
+		serverID := DecodeProviderID(providerID)
+		server, err = ex.GetMachineByID(ctx, serverID)
 	} else {
 		server, err = ex.getMachineByName(ctx, machineName)
 	}
@@ -677,8 +677,8 @@ func (ex *Executor) deleteVolume(ctx context.Context, machineName string) error 
 	return nil
 }
 
-// getMachineByProviderID fetches the data for a server based on a provider-encoded ID.
-func (ex *Executor) getMachineByID(ctx context.Context, serverID string) (*servers.Server, error) {
+// GetMachineByID fetches the data for a server based on a provider-encoded ID.
+func (ex *Executor) GetMachineByID(ctx context.Context, serverID string) (*servers.Server, error) {
 	klog.V(2).Infof("finding server with [ID=%q]", serverID)
 	server, err := ex.Compute.GetServer(ctx, serverID)
 	if err != nil {

--- a/pkg/driver/executor/utils.go
+++ b/pkg/driver/executor/utils.go
@@ -16,8 +16,8 @@ func encodeProviderID(region string, machineID string) string {
 	return fmt.Sprintf("openstack:///%s/%s", region, machineID)
 }
 
-// decodeProviderID decodes a provider-encoded ID into the ID of the server.
-func decodeProviderID(id string) string {
+// DecodeProviderID decodes a provider-encoded ID into the ID of the server.
+func DecodeProviderID(id string) string {
 	splitProviderID := strings.Split(id, "/")
 	return splitProviderID[len(splitProviderID)-1]
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
This is needed for the managed-infra scenario of self hosted shoots.
When it is unimplemented, mcm tries to fallback to the provider id and the `machine` label on the node.
In the case of self hosted shoots, the machine label does not land on the node after pivot to the controlplane machine, as the machine is created without a target kubeconfig.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
`GetMachineStatus` is now implemented.
```
